### PR TITLE
New feature (more options for subtitles extract) + a few bug fixed

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,8 @@
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.libs << 'test'
+end
+
+desc "Run tests"
+task :default => :test

--- a/lib/mkv.rb
+++ b/lib/mkv.rb
@@ -27,9 +27,9 @@ module MKV
   # @return [Logger]
   def self.logger
     return @logger if @logger
-    logger = Logger.new(STDOUT)
-    logger.level = Logger::INFO
-    @logger = logger
+    log = Logger.new(STDOUT)
+    log.level = Logger::INFO
+    @logger = log
   end
 
   # Set the path of the mkvinfo binary.

--- a/lib/mkv/track.rb
+++ b/lib/mkv/track.rb
@@ -27,7 +27,7 @@ module MKV
       end
 
       if @type == 'audio' || @type == 'subtitles'
-        @language = (data.match(/language: (\w+)/i) || ['eng'])[1]
+        @language = (data.match(/language: (\w+)/i) || [nil, 'eng'])[1]
         @enabled = (data.match(/enabled: (\d+)/i) || [0, 1])[1] != '0'
         @default = (data.match(/default flag: (\d+)/i) || [0, 0])[1] != '0'
         @forced = (data.match(/forced flag: (\d+)/i) || [0, 0])[1] != '0'

--- a/test/test_mkv.rb
+++ b/test/test_mkv.rb
@@ -1,0 +1,19 @@
+require 'test/unit'
+require 'mkv'
+
+# Put your own test mkv file path here
+TEST_MOVIE_FILE = "/Users/Alex/Downloads/rj/rj.mkv"
+
+class MkvTest < Test::Unit::TestCase
+  def test_open_movie
+    movie = MKV::Movie.new(TEST_MOVIE_FILE)
+    assert_equal movie.valid?, true
+  end
+
+  def test_extract_eng_subtitles
+    movie = MKV::Movie.new(TEST_MOVIE_FILE)
+    assert movie.has_subtitles?('eng')
+    movie.extract_subtitles(language: 'eng')
+  end
+
+end


### PR DESCRIPTION
Features:
- Subtitles extraction: can select just one language
- Subtitles extraction: destination directory is, by default, the same as source directory

Fixes and improvements:
- Added unit testing framework and 2 tests
- Fixed a bug in Movie#valid?
- Fixed a bug when no language defined => 'eng'
