### PR TITLE
Fixed the gemspec and updated the Gemfile to remove warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec

--- a/mkv.gemspec
+++ b/mkv.gemspec
@@ -12,9 +12,10 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/gokuu/mkv"
   s.summary     = "Reads MKV info."
   s.description = "Simple wrapper around MKVToolNix's mkvinfo utility to get data from MKV movies, and mkvextract to extract subtitles."
-  
+
+  s.add_dependency("awesome_print", "~> 1.2")
   s.add_development_dependency("rspec", "~> 2.7")
-  s.add_development_dependency("rake", "~> 0.9.2")
+  s.add_development_dependency("rake", "~> 0.9", ">= 0.9.2")
 
   s.files        = Dir.glob("lib/**/*") + %w(README.md LICENSE CHANGELOG)
 end


### PR DESCRIPTION
Updated the Gemfile to use https, so that bundle install wont' give a warning. Updated the Gemspec file to declare a dependency that was used, otherwise the gem can't be used directly after installing (it will give an error). Also fixed the other dependencies to not give an error anymore when building the gem.
